### PR TITLE
initial commit of type providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ deploy:
 
     configurations:
     - name:  my-deployment
+      group: typeprovider
+      state: present
+      descriptorURL: https://cloudtasks.googleapis.com/$discovery/rest?version=v2beta3
+      apiOptions: ./api-options-definition.yaml # path to api options YAML
+    - name:  my-deployment
       group: deployment
       state: present
       path: ./my-deployment.yaml

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ deploy:
     - myOtherCtxVar: ctxVal2
 
     configurations:
-    - name:  my-deployment
+    - name:  my-provider
       group: typeprovider
       state: present
       descriptorURL: https://cloudtasks.googleapis.com/$discovery/rest?version=v2beta3

--- a/config.go
+++ b/config.go
@@ -25,22 +25,24 @@ import (
 )
 
 type GdmConfigurationSpec struct {
-	Vars         map[string]interface{} `json:"vars"`
-	GdmVersion   string                 `json:"version"`
-	Group        string                 `json:"group"`
-	State        string
-	Name         string
-	Path         string
-	Config       string
-	Template     string
-	Description  string
-	Labels       map[string]string
-	Properties   map[string]interface{}
-	AutoRollback bool `json:"automaticRollbackOnError"`
-	CreatePolicy string
-	DeletePolicy string
-	Status       string
-	PassAction   bool `json:"passAction"`
+	Vars          map[string]interface{} `json:"vars"`
+	GdmVersion    string                 `json:"version"`
+	Group         string                 `json:"group"`
+	State         string
+	Name          string
+	Path          string
+	Config        string
+	Template      string
+	Description   string
+	DescriptorURL string
+	APIOptions    string
+	Labels        map[string]string
+	Properties    map[string]interface{}
+	AutoRollback  bool `json:"automaticRollbackOnError"`
+	CreatePolicy  string
+	DeletePolicy  string
+	Status        string
+	PassAction    bool `json:"passAction"`
 }
 
 func (spec *GdmConfigurationSpec) Validate() error {
@@ -52,7 +54,7 @@ func (spec *GdmConfigurationSpec) Validate() error {
 		return fmt.Errorf("configuration error: %v", err)
 	}
 
-	err = IsParamInRange("group", spec.Group, "deployment", "composite")
+	err = IsParamInRange("group", spec.Group, "deployment", "composite", "typeprovider")
 	if err != nil {
 		return fmt.Errorf("configuration error: %v", err)
 	}

--- a/gdm.go
+++ b/gdm.go
@@ -67,6 +67,8 @@ func GdmExecute(context *GdmPluginContext, spec *GdmConfigurationSpec) error {
 //------------------------------------
 func getGdmCommand(spec *GdmConfigurationSpec) GdmCommand {
 	switch spec.Group {
+	case "typeprovider":
+		return NewTypeProviderCmd()
 	case "deployment":
 		return NewGdmDeploymentCmd()
 	case "composite":
@@ -117,9 +119,7 @@ func executeDeploymentAction(context *GdmPluginContext, spec *GdmConfigurationSp
 func getCmdPrelude(command GdmCommand, spec *GdmConfigurationSpec) []string {
 	var cmd []string
 	switch spec.Group {
-	case "deployment":
-		cmd = []string{"deployment-manager", command.Name()}
-	case "composite":
+	case "typeprovider", "deployment","composite":
 		cmd = []string{"deployment-manager", command.Name()}
 	}
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -7,5 +7,6 @@ Code Organization
  * gdm.go: GDM business logic + command interface
  * composite.go: GDM "types" (composite) command implementation
  * deployment.go: GDM "deployments" command implementation
+ * typeprovider.go: GDM "type-providers" command implementation
 
 

--- a/typeprovider.go
+++ b/typeprovider.go
@@ -1,0 +1,94 @@
+//==============================================================================
+//
+// drone-gdm/plugin/composite.go: GDM logic for "composite types"
+//
+// Copyright (c) 2017 The New York Times Company
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this library except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//------------------------------------------------------------------------------
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+type GdmTypeProviderCmd struct{}
+
+func NewTypeProviderCmd() *GdmTypeProviderCmd {
+	return &GdmTypeProviderCmd{}
+}
+
+func (command *GdmTypeProviderCmd) Name() string {
+	return "type-providers"
+}
+
+// On success, return a bool indicating whether or not the named deployment
+// already exists.
+func (command *GdmTypeProviderCmd) Exists(context *GdmPluginContext, spec *GdmConfigurationSpec) (bool, error) {
+	fmt.Printf("drone-gdm: Checking for existing %s \"%s\"...\n", spec.Group, spec.Name)
+	var deployExists bool
+
+	gcmd := getCmdPrelude(command, spec)
+	args := append(gcmd, []string{
+		"list",
+		fmt.Sprintf("--project=%s", context.Project),
+		fmt.Sprintf("--filter=name=%s", spec.Name),
+	}...)
+
+	result := RunGcloud(context, args...)
+	if result.Error != nil {
+		return deployExists, fmt.Errorf("error listing type providers: %s\n", result.Stderr.String())
+	}
+
+	if strings.TrimSpace(result.Stdout.String()) != "" {
+		fmt.Printf("drone-gdm: \"%s\" exists\n", spec.Name)
+		deployExists = true
+	} else {
+		fmt.Printf("drone-gdm: \"%s\" does not exist\n", spec.Name)
+		deployExists = false
+	}
+	return deployExists, nil
+}
+
+func (command *GdmTypeProviderCmd) Action(spec *GdmConfigurationSpec, exists bool) (string, error) {
+	switch {
+	case spec.State == "latest":
+		return "", fmt.Errorf("\"latest\" is not a valid state for type providers")
+	case exists && spec.State == "absent":
+		return "delete", nil
+	case !exists && spec.State == "present":
+		return "create", nil
+	case exists && spec.State == "present":
+		return "update", nil
+	}
+	return "", nil
+}
+
+func (command *GdmTypeProviderCmd) Options(context *GdmPluginContext, spec *GdmConfigurationSpec, action string) ([]string, error) {
+	var options []string
+
+	if action != "delete" && spec.DescriptorURL == "" {
+		return options, fmt.Errorf("\"descriptorURL\" is required for \"%s\"", spec.Group)
+	}
+	addOptIfPresent(&options, "--descriptor-url", spec.DescriptorURL)
+	if (spec.APIOptions != "") {
+		templatePath := getAdjustedPath(spec.APIOptions, context.Dir)
+		addOptIfPresent(&options, "--api-options-file", templatePath)
+	}
+	return options, nil
+}
+
+// EOF

--- a/util/0.8-test.bash
+++ b/util/0.8-test.bash
@@ -16,6 +16,14 @@ export PLUGIN_DRYRUN="true"
 read -r -d '' PLUGIN_CONFIGURATIONS <<'EOF'
 [
 	{
+		"name": "my-type-provider1",
+		"group": "typeprovider",
+		"state": "present",
+		"apiOptions": "./my-composite1.yml",
+		"version": "beta",
+		"descriptorURL": "https://cloudtasks.googleapis.com/$discovery/rest?version=v2beta3"
+	},
+	{
 		"name": "my-deployment1",
 		"group": "deployment",
 		"state": "latest",


### PR DESCRIPTION
This is an implementation of GDM's [custom type providers](https://cloud.google.com/deployment-manager/docs/configuration/type-providers/creating-type-provider) functionality, which allows adding new type providers that other deployments can use. I've tested using the local test script, and the gcloud commands look approximately like what I'd expect, but let me know if there's other pieces I'm missing or that should work differently!