### PR TITLE
match yaml struct tag to the json struct tag

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ import (
 
 type GdmConfigurationSpec struct {
 	Vars          map[string]interface{} `json:"vars"`
-	GdmVersion    string                 `json:"version"`
+	GdmVersion    string                 `json:"version" yaml:"version"`
 	Group         string                 `json:"group"`
 	State         string
 	Name          string


### PR DESCRIPTION
I was seeing a bug where specifying the gcloud version in an external config file wasn't working as expected; this should fix that.